### PR TITLE
Hide users type

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -152,7 +152,6 @@ router.post("/get_types", function(req, res){
   }).then(function(resp){
 
     var mappings = [];
-    var visualization_types = [];
     if(resp[INDEX]){
       async.each(Object.keys(resp[INDEX].mappings), function(mapping, cb){
         var last = mapping.split('_');
@@ -168,11 +167,6 @@ router.post("/get_types", function(req, res){
           mappings.push(mapping.slice(0, mapping.indexOf('_' + last)));
         }
 
-        var mapping = exclude.indexOf(last) != -1 ? mapping.slice(0, mapping.indexOf('_' + last)) : mapping;
-
-        if(visualization_types.indexOf(mapping + '_visualizations') == -1){
-          visualization_types.push(mapping + '_visualizations');
-        }
         cb();
       }, function(err){
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -157,14 +157,19 @@ router.post("/get_types", function(req, res){
         var last = mapping.split('_');
         last = last[last.length-1];
 
-        var exclude = ['fields', 'visualizations'];
+        var suffixesToExclude = ['fields', 'visualizations'];
+        var typesToExclude = ['users'];
 
-        if(mappings.indexOf(mapping) == -1 && exclude.indexOf(last) == -1){
+        if (mappings.indexOf(mapping) == -1 && suffixesToExclude.indexOf(last) == -1 && typesToExclude.indexOf(mapping) == -1) {
           mappings.push(mapping);
         }
         // If there are empty mappings, show the mapping in the UI anyways
-        else if(exclude.indexOf(last) != -1 && mappings.indexOf(mapping.slice(0, mapping.indexOf('_' + last))) == -1){
-          mappings.push(mapping.slice(0, mapping.indexOf('_' + last)));
+        else if (suffixesToExclude.indexOf(last) != -1) {
+          var mappingName = mapping.slice(0, mapping.indexOf('_' + last));
+
+          if (mappings.indexOf(mappingName) == -1 && typesToExclude.indexOf(mappingName) == -1) {
+            mappings.push(mappingName);
+          }
         }
 
         cb();


### PR DESCRIPTION
This branch makes sure that the users type stored in Elasticsearch is not shown on the admin page and on the search page. The users type is no longer shown in the list of mappings on the admin page and in the list evidence types on the search page.